### PR TITLE
chore: Add account and address schemas

### DIFF
--- a/partials/schemas/AbstractAccount.yaml
+++ b/partials/schemas/AbstractAccount.yaml
@@ -1,0 +1,60 @@
+components:
+  schemas:
+    AbstractAccount:
+      title: Account
+      description: |
+        An account describes an organizational unit to manage access to systems for one or multiple users.
+
+        This is the base type for the more concrete usages and not used directly within operations.
+      type: object
+      properties:
+        name:
+          type: string
+          example: John Doe
+          description: Name of the account, can be chosen freely but should be kept terse and descriptive.
+          minLength: 1
+          maxLength: 256
+        isInstaller:
+          x-internal: true
+          type: boolean
+          description: Specifies if account is an installer.
+          example: false
+        email:
+          type: string
+          format: email
+          example: john@doe.com
+          description: The email field of the account can optionally be chosen e.g. for contact purposes (in order to reach the responsible person for the account).
+          maxLength: 256
+        audience:
+          x-internal: true # reason: reference to Auth0
+          type: string
+          description: Audience is an internal ID that should not be relied upon by external parties in any way.
+        solution:
+          $ref: '#/components/schemas/AccountSolution'
+        modules:
+          $ref: '#/components/schemas/Modules'
+    AccountSolution:
+      type: string
+      description: |
+        Represents the supported solutions within the account:
+        - HOME if the account contains household-like systems. 
+        - CHARGE if the account is used solely for charging station fleet management.
+        - GENERAL if unsure what the account should contain or if it's a mix of multiple solutions.
+        - SMART_DISTRICT if the account is used solely for smart district management.
+        If not set, the parent account's solution will be assumed.
+      enum:
+        - HOME
+        - CHARGE
+        - GENERAL
+        - SMART_DISTRICT
+        - MICROGRID
+        - HOME_VIRTUAL_METERING
+        - COMMERCIAL
+        - CUSTOM_P2P
+    Modules:
+      x-internal: true # reason: "cheap" approach for enabling modules, not API-user suitable.
+      description: Modules that are enabled for this account.
+      type: array
+      items:
+        type: string
+        enum: [ "Grid Protector", "Web App", "Energy Billing", "Energy Optimizer", "Mobile App", "V2G/V2H", "Multi-Energy Opt", "Peak Shaver", "Cloud Connector", "VPP", "Tariff Timer", "API","Grid Signal Processor" ]

--- a/partials/schemas/AbstractLocation.yaml
+++ b/partials/schemas/AbstractLocation.yaml
@@ -1,0 +1,40 @@
+components:
+  schemas:
+    AbstractLocation:
+      type: object
+      properties:
+        city:
+          description: The city of the location.
+          type: string
+          example: Aachen
+        country:
+          description: The country of the location.
+          type: string
+          example: Germany
+        addressLine1:
+          description: |
+            First line of the location's address, typically containing the 
+            main information such as the street name and house number.
+          type: string
+          example: Oppenhoffallee 143
+        addressLine2:
+          description: |
+            Second line of the location's address, typically containing additional 
+            information such as apartment numbers, suite numbers, or other details 
+            that can help in identifying the exact location of the address.
+          type: string
+        addressLine3:
+          description: |
+            Third line of the location's address, typically containing any other 
+            details that can help in identifying the exact location of the address.
+          type: string
+        addressLine4:
+          description: |
+            Fourth line of the location's address, typically containing any other 
+            details that can help in identifying the exact location of the address.
+          type: string
+        timeZone:
+          description: The TZ Identifier of the location's timezone.
+          type: string
+          example: Europe/Berlin
+          readOnly: true

--- a/partials/schemas/Account.yaml
+++ b/partials/schemas/Account.yaml
@@ -1,0 +1,50 @@
+components:
+  schemas:
+    Account:
+      title: Account
+      description: |
+        An account describes an organizational unit to manage access to systems for one or multiple users.
+      type: object
+      readOnly: true
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/grid-x/api/refs/heads/main/partials/schemas/AbstractAccount.yaml#/components/schemas/AbstractAccount'
+        - properties:
+            id:
+              type: string
+              format: uuid
+              example: 49a4f165-8233-426b-a1a4-e569665a25dd
+              description: Uniquely identifies the account.
+            parentID:
+              type: string
+              format: uuid
+              example: 19a4f165-8233-426b-a1a4-e569665a25dd
+              description: Parent of the account for a tree-like account structure. Only the root account does not have a parent ID.
+            createdAt:
+              type: string
+              format: date-time
+              description: Specifies when the account was created.
+            updatedAt:
+              type: string
+              format: date-time
+              description: Specifies when the account was updated.
+            systemsCount:
+              type: integer
+              description: SystemCount is the number of systems assigned to this account
+              example: 1
+            kind:
+              $ref: '#/components/schemas/AccountKind'
+            mainAddress:
+              $ref: 'https://raw.githubusercontent.com/grid-x/api/refs/heads/main/partials/schemas/Address.yaml#/components/schemas/Address'
+            customization:
+              # type: ANY value - omit type to indicate to codegen
+              description: Customization can be used to store arbitrary data.
+          required:
+            - id
+            - createdAt
+            - updatedAt
+    AccountKind:
+      type: string
+      enum:
+        - b2b
+        - end-user
+      description: If b2b, the account is a regular account. If end-user, the account is a customer account which contains just one user.

--- a/partials/schemas/Address.yaml
+++ b/partials/schemas/Address.yaml
@@ -1,48 +1,10 @@
 components:
   schemas:
-    AbstractLocation:
-      type: object
-      properties:
-        city:
-          description: The city of the location.
-          type: string
-          example: Aachen
-        country:
-          description: The country of the location.
-          type: string
-          example: Germany
-        addressLine1:
-          description: |
-            First line of the location's address, typically containing the 
-            main information such as the street name and house number.
-          type: string
-          example: Oppenhoffallee 143
-        addressLine2:
-          description: |
-            Second line of the location's address, typically containing additional 
-            information such as apartment numbers, suite numbers, or other details 
-            that can help in identifying the exact location of the address.
-          type: string
-        addressLine3:
-          description: |
-            Third line of the location's address, typically containing any other 
-            details that can help in identifying the exact location of the address.
-          type: string
-        addressLine4:
-          description: |
-            Fourth line of the location's address, typically containing any other 
-            details that can help in identifying the exact location of the address.
-          type: string
-        timeZone:
-          description: The TZ Identifier of the location's timezone.
-          type: string
-          example: Europe/Berlin
-          readOnly: true
     Address:
       title: Address
       description: Represents a physical address of a customer.
       allOf:
-        - $ref: '#/components/schemas/AbstractLocation'
+        - $ref: 'https://raw.githubusercontent.com/grid-x/api/refs/heads/main/partials/schemas/AbstractLocation.yaml#/components/schemas/AbstractLocation'
         - type: object
           properties:
             postalcode:

--- a/partials/schemas/Address.yaml
+++ b/partials/schemas/Address.yaml
@@ -1,0 +1,57 @@
+components:
+  schemas:
+    AbstractLocation:
+      type: object
+      properties:
+        city:
+          description: The city of the location.
+          type: string
+          example: Aachen
+        country:
+          description: The country of the location.
+          type: string
+          example: Germany
+        addressLine1:
+          description: |
+            First line of the location's address, typically containing the 
+            main information such as the street name and house number.
+          type: string
+          example: Oppenhoffallee 143
+        addressLine2:
+          description: |
+            Second line of the location's address, typically containing additional 
+            information such as apartment numbers, suite numbers, or other details 
+            that can help in identifying the exact location of the address.
+          type: string
+        addressLine3:
+          description: |
+            Third line of the location's address, typically containing any other 
+            details that can help in identifying the exact location of the address.
+          type: string
+        addressLine4:
+          description: |
+            Fourth line of the location's address, typically containing any other 
+            details that can help in identifying the exact location of the address.
+          type: string
+        timeZone:
+          description: The TZ Identifier of the location's timezone.
+          type: string
+          example: Europe/Berlin
+          readOnly: true
+    Address:
+      title: Address
+      description: Represents a physical address of a customer.
+      allOf:
+        - $ref: '#/components/schemas/AbstractLocation'
+        - type: object
+          properties:
+            postalcode:
+              description: The postal code of the location.
+              type: string
+              example: '52062'
+            region:
+              description: The region of the address.
+              type: string
+            telephone:
+              description: The telephone number of the customer.
+              type: string


### PR DESCRIPTION
Adding the `Account` schema because it is referenced by both the inventory service and backend. `Address` needed to be included as well because it is referenced in the Account schema. 