### PR TITLE
chore: Add EV charging schedule schema

### DIFF
--- a/partials/schemas/AbstractEVChargingSchedule.yaml
+++ b/partials/schemas/AbstractEVChargingSchedule.yaml
@@ -1,0 +1,26 @@
+components:
+  schemas:
+    AbstractEVChargingSchedule:
+      title: EV Charging Schedule
+      description: |
+        An Electric Vehicle charging schedule represents an interval in which
+        the electric vehicle is supposed to charge at a defined limit.
+      type: object
+      properties:
+        from:
+          type: string
+          format: date-time
+          example: '2021-11-04T00:00:00Z'
+          description: |
+            Specifies when the schedule should start in RFC3339 format.
+        to:
+          type: string
+          format: date-time
+          example: '2021-11-04T00:30:00Z'
+          description: |
+            Specifies when the schedule should end in RFC3339 format.
+        limit:
+          $ref: "https://raw.githubusercontent.com/grid-x/api/refs/heads/main/partials/schemas/Unit.yaml#/components/schemas/PositivePower"
+          description: |
+            The maximum amount of power in Watts that will be used for scheduling charging in the interval [from, to].
+          example: 75000

--- a/partials/schemas/EVChargingSchedule.yaml
+++ b/partials/schemas/EVChargingSchedule.yaml
@@ -1,0 +1,23 @@
+components:
+  schemas:
+    EVChargingSchedule:
+      title: EV Charging Schedule
+      type: object
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/grid-x/api/refs/heads/main/partials/schemas/AbstractEVChargingSchedule.yaml#/components/schemas/AbstractEVChargingSchedule'
+        - properties:
+            id:
+              type: string
+              format: uuid
+              example: ec4d0c89-a604-49ac-82f0-427f9cb42204
+              readOnly: true
+            updatedAt:
+              type: string
+              format: date-time
+              readOnly: true
+              description: Specifies when the schedule was updated the last time.
+        - required:
+            - id
+            - from
+            - to
+            - limit

--- a/partials/schemas/Unit.yaml
+++ b/partials/schemas/Unit.yaml
@@ -1,0 +1,8 @@
+components:
+  schemas:
+    PositivePower:
+      title: Positive Power in Watt.
+      type: integer
+      format: int64
+      minimum: 0
+      example: 501


### PR DESCRIPTION
The `EVChargingSchedule` schema is referenced both by the EVCS API endpoints and the `Systems` response schema. 