### PR TITLE
chore: Add product option and product functionality schemas

### DIFF
--- a/partials/schemas/AbstractProductFunctionality.yaml
+++ b/partials/schemas/AbstractProductFunctionality.yaml
@@ -1,0 +1,22 @@
+components:
+  schemas:
+    AbstractProductFunctionality:
+      description: |
+        A product functionality describes a feature.
+
+        It is used to manage access to this feature via product options.
+
+        This is the base type for the more concrete usages and not used directly within operations.
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 256
+          description: Name of the product functionality.
+          example: EV Manager
+        hide:
+          type: boolean
+          description: Indicates whether the product functionality should be hidden or shown.
+        description:
+          type: string
+          description: Describes the purpose of the product functionality.

--- a/partials/schemas/AbstractProductOption.yaml
+++ b/partials/schemas/AbstractProductOption.yaml
@@ -1,0 +1,19 @@
+components:
+  schemas:
+    AbstractProductOption:
+      title: Product Option
+      description: |
+        A product option describes a set of features whose access should be restricted from or granted to users of a system.
+
+        Systems can be assigned a product option to manage their access to these features.
+
+        This is the base type for the more concrete usages and not used directly within operations.
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the product option.
+          example: Default Product Option
+        description:
+          type: string
+          description: Describes the purpose of the product option.

--- a/partials/schemas/ProductFunctionality.yaml
+++ b/partials/schemas/ProductFunctionality.yaml
@@ -1,0 +1,16 @@
+components:
+  schemas:
+    ProductFunctionality:
+      type: object
+      allOf:
+        - $ref: '"https://raw.githubusercontent.com/grid-x/api/refs/heads/main/partials/schemas/AbstractProductFunctionality.yaml#/components/schemas/AbstractProductFunctionality'
+        - properties:
+            id:
+              description: Unique identifier of the product functionality.
+              type: string
+              format: uuid
+              example: 4e3392ce-ed94-4946-8a11-665e0443723e
+          required:
+            - id
+            - name
+            - hide

--- a/partials/schemas/ProductOption.yaml
+++ b/partials/schemas/ProductOption.yaml
@@ -1,0 +1,47 @@
+components:
+  schemas:
+    ProductOption:
+      type: object
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/grid-x/api/refs/heads/main/partials/schemas/AbstractProductOption.yaml#/components/schemas/AbstractProductOption'
+        - properties:
+            id:
+              description: Unique identifier of the product option.
+              type: string
+              format: uuid
+              example: d5166f02-8b56-4200-90bd-35d3d17391b4
+            accountID:
+              description: Unique identifier of the account that owns the product option.
+              type: string
+              format: uuid
+              example: d73b6749-2c32-4bca-ab73-50d8e3744edf
+            isDefault:
+              type: boolean
+              description: Indicates whether the product option should be assigned by default to all systems of the owning account.
+            functionalities:
+              description: The default functionalities that a product option restricts access to. Deprecated - Use `showFunctionalities` and `hideFunctionalities` instead.
+              type: array
+              readOnly: true
+              deprecated: true
+              items:
+                $ref: 'https://raw.githubusercontent.com/grid-x/api/refs/heads/main/partials/schemas/ProductFunctionality.yaml#/components/schemas/ProductFunctionality'
+            hideFunctionalities:
+              readOnly: true
+              description: The default functionalities that a product option restricts access to. Must be of type `hide=true`.
+              type: array
+              items:
+                $ref: 'https://raw.githubusercontent.com/grid-x/api/refs/heads/main/partials/schemas/ProductFunctionality.yaml#/components/schemas/ProductFunctionality'
+            showFunctionalities:
+              readOnly: true
+              description: The extra functionalities that a product option grants access to. Must be of type `hide=false`.
+              type: array
+              items:
+                $ref: 'https://raw.githubusercontent.com/grid-x/api/refs/heads/main/partials/schemas/ProductFunctionality.yaml#/components/schemas/ProductFunctionality'
+          required:
+            - id
+            - accountID
+            - name
+            - isDefault
+            - functionalities
+            - hideFunctionalities
+            - showFunctionalities


### PR DESCRIPTION
Adding to the shared schemas because the `ProductOption` is part of the `System` schema in Inventory, but is managed in the product option API and Accounts APIs.