### PR TITLE
feat(user): extend user metadata

### DIFF
--- a/partials/schemas/UserWithoutAuth.yaml
+++ b/partials/schemas/UserWithoutAuth.yaml
@@ -106,3 +106,7 @@ components:
         analyticsEnabled:
           description: Indicates whether the user allows anonymous analytic data to be use by gridX.
           type: boolean
+        analyticsLastEnabledAt:
+          description: Indicates when the user gave their consent to enable analytics. This will help with re-requesting consent if/when the privacy policy changes.
+          type: string
+          format: date-time


### PR DESCRIPTION
Extend the user metadata with `analyticsLastEnabledAt` to indicate when the user gave their consent for enabling analytics. This will help with re-requesting consent if/when the privacy policy changes.

This change is part of this [ticket](https://grid-x.atlassian.net/browse/WEB-984)