### PR TITLE
fix(partials/parameters/filter): use correct perPage maximum

### DIFF
--- a/partials/parameters/filter.yaml
+++ b/partials/parameters/filter.yaml
@@ -21,7 +21,7 @@ components:
         format: int32
         default: 20
         minimum: 20
-        maximum: 100
+        maximum: 500
       example: 50
     sort:
       name: sort


### PR DESCRIPTION
https://grid-x.slack.com/archives/C06LFNR4TC1/p1755789517498159?thread_ts=1755774624.219279&cid=C06LFNR4TC1

Checked, the max is 500 both in [inventory](https://github.com/grid-x/inventory/blob/fcaa35ebe0e3dd387e69422452771080f6bbe6d0/pkg/model/list.go#L12) and [backend](https://github.com/grid-x/backend/blob/189651b63b96b08c02981b7d3546fe1b5ac1f33f/pkg/model/lists.go#L13)