### PR TITLE
chore: Make example more useable

### DIFF
--- a/partials/parameters/filter.yaml
+++ b/partials/parameters/filter.yaml
@@ -10,7 +10,7 @@ components:
         format: int32
         default: 1
         minimum: 1
-      example: 5
+      example: 1
     perPage:
       name: per_page
       description: |
@@ -22,7 +22,7 @@ components:
         default: 20
         minimum: 20
         maximum: 500
-      example: 50
+      example: 10
     sort:
       name: sort
       description: Sort results based on a key.


### PR DESCRIPTION
Having page 5 as an example here means the default example will not return anything in many cases when copying the code/shell command or using the interactive console.

Setting it to 1 now.