### PR TITLE
fix: remove email format validation from Account schema

### DIFF
--- a/partials/schemas/AbstractAccount.yaml
+++ b/partials/schemas/AbstractAccount.yaml
@@ -21,7 +21,6 @@ components:
           example: false
         email:
           type: string
-          format: email
           example: john@doe.com
           description: The email field of the account can optionally be chosen e.g. for contact purposes (in order to reach the responsible person for the account).
           maxLength: 256


### PR DESCRIPTION
The `format: email` constraint on AbstractAccount's email field causes ogen-generated clients to reject responses containing accounts with invalid emails (such as an empty string or a domain without a localpart).

Since this schema is used in read responses, format validation should be enforced on the write path instead.